### PR TITLE
[feat] 히스토리 상세 페이지에 TTS 음성 읽기 기능 추가

### DIFF
--- a/src/app/history-crud-test/page.tsx
+++ b/src/app/history-crud-test/page.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { summarizeFoodItem } from '@/actions/chat'
 import { useFoodStore } from '@/store/useFoodsHistoryStore'
 import type { FoodHistoryEntry } from '@/types/FoodData'
+import type { FoodNutrient } from '@/types/FoodItem'
 
 interface CreationFormState {
   productName: string
@@ -16,6 +17,7 @@ interface CreationFormState {
   tags: string
   ingredients: string
   allergens: string
+  nutritions: string
 }
 
 const createInitialFormState = (): CreationFormState => ({
@@ -26,6 +28,7 @@ const createInitialFormState = (): CreationFormState => ({
   tags: '테스트, 샘플',
   ingredients: '밀, 대두',
   allergens: '밀, 대두',
+  nutritions: '탄수화물, 50, g, 17|단백질, 5, g, 9|지방, 10, g, 15|나트륨, 500, mg, 25',
 })
 
 const parseCommaSeparatedList = (value: string): string[] =>
@@ -33,6 +36,20 @@ const parseCommaSeparatedList = (value: string): string[] =>
     .split(',')
     .map(item => item.trim())
     .filter(Boolean)
+
+const parseNutritions = (value: string): FoodNutrient[] => {
+  if (!value.trim()) return []
+
+  return value.split('|').map(item => {
+    const parts = item.split(',').map(part => part.trim())
+    return {
+      name: parts[0] || '',
+      amount: parseFloat(parts[1]) || 0,
+      unit: parts[2] || '',
+      dailyRatio: parseFloat(parts[3]) || undefined,
+    }
+  }).filter(nutrition => nutrition.name && nutrition.amount > 0)
+}
 
 const buildFoodEntry = (form: CreationFormState, nextOrder: number): FoodHistoryEntry => {
   const now = Date.now()
@@ -45,7 +62,7 @@ const buildFoodEntry = (form: CreationFormState, nextOrder: number): FoodHistory
     tags: parseCommaSeparatedList(form.tags),
     ingredients: parseCommaSeparatedList(form.ingredients),
     allergens: parseCommaSeparatedList(form.allergens),
-    nutritions: [],
+    nutritions: parseNutritions(form.nutritions),
     certifications: [],
     timestamp: now,
     order: nextOrder,
@@ -236,6 +253,18 @@ export default function CreationTestPage() {
               rows={2}
               value={form.allergens}
               onChange={onInputChange}
+            />
+          </label>
+
+          <label className="flex flex-col text-sm font-medium">
+            영양성분 (|로 구분, 형식: 이름, 함량, 단위, 일일비율%)
+            <textarea
+              className="mt-1 rounded border border-gray-300 p-2"
+              name="nutritions"
+              rows={3}
+              value={form.nutritions}
+              onChange={onInputChange}
+              placeholder="예: 탄수화물, 50, g, 17|단백질, 5, g, 9|지방, 10, g, 15|나트륨, 500, mg, 25"
             />
           </label>
 

--- a/src/app/history/[order]/_components/DescriptionSection.tsx
+++ b/src/app/history/[order]/_components/DescriptionSection.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { STYLE } from '../_constants/style'
+
+interface DescriptionSectionProps {
+  source: string
+  title: string
+}
+
+export default function DescriptionSection({ source, title }: DescriptionSectionProps) {
+  return (
+    <section className={STYLE.HISTORY_INFO.SECTION}>
+      <h3 className={STYLE.HISTORY_INFO.SECTION_H3}>{title}</h3>
+      <p className={STYLE.HISTORY_INFO.PARAGRPAPH}>
+        {source}
+      </p>
+    </section>
+  )
+}

--- a/src/hooks/useTTS.ts
+++ b/src/hooks/useTTS.ts
@@ -1,0 +1,52 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+export function useTTS() {
+  const isTTSEnabledRef = useRef(true)
+  const [isTTSEnabled, setIsTTSEnabled] = useState(true)
+  const [isSpeaking, setIsSpeaking] = useState(false)
+
+  const speak = (text: string) => {
+    if (!isTTSEnabledRef.current) return
+
+    const utterance = new SpeechSynthesisUtterance(text)
+    utterance.lang = 'ko-KR'
+    utterance.rate = 1.0
+    
+    utterance.onstart = () => {
+      setIsSpeaking(true)
+    }
+    
+    utterance.onend = () => {
+      setIsSpeaking(false)
+    }
+    
+    utterance.onerror = () => {
+      setIsSpeaking(false)
+    }
+    
+    window.speechSynthesis.speak(utterance)
+  }
+
+  const stopSpeak = () => {
+    window.speechSynthesis.cancel()
+    setIsSpeaking(false)
+  }
+
+  const toggleTTS = () => {
+    isTTSEnabledRef.current = !isTTSEnabledRef.current
+    setIsTTSEnabled(isTTSEnabledRef.current)
+    if (!isTTSEnabledRef.current) {
+      stopSpeak()
+    }
+  }
+
+  return {
+    speak,
+    stopSpeak,
+    toggleTTS,
+    isTTSEnabled,
+    isSpeaking,
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as cn } from './cn'
+export { default as parseFoodToRead } from './parseFoodToRead'

--- a/src/utils/parseFoodToRead.ts
+++ b/src/utils/parseFoodToRead.ts
@@ -1,0 +1,17 @@
+import type { FoodItem } from "@/types/FoodItem";
+
+export default function parseFoodToRead(item: FoodItem) {
+    const allergensText = item.allergens.length > 0 ? item.allergens.join(', ') : '없음'
+    const nutritionsText = item.nutritions.length > 0 
+        ? item.nutritions.map(nu => `${nu.name} ${nu.amount}${nu.unit}`).join(', ')
+        : '없음'
+    const ingredientsText = item.ingredients.length > 0 ? item.ingredients.join(', ') : '없음'
+    
+    return `${item.productName}
+      총 내용량 ${item.weight}
+      알레르기 유발 성분 ${allergensText}
+      영양성분 ${nutritionsText}
+      원재료명 및 함량 ${ingredientsText}
+      AI 요약 ${item.description || '없음'}
+      `.trim()
+}


### PR DESCRIPTION
## PR 체크리스트

- [x] 코드 변경 사항을 설명하는 커밋 메시지를 작성했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 진행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 빌드/타입 에러 없음
- [x] ESLint/Prettier 적용 (`bun lint`, `bun format`)

## 변경 내용 요약

- useTTS 훅 추가로 Web Speech API 기반 음성 출력 구현
- parseFoodToRead 유틸 함수 추가로 FoodItem 데이터를 음성용 텍스트로 변환
- HistoryInfoContainer에 음성 듣기 버튼 추가 (Volume1 아이콘)
- DescriptionSection 컴포넌트 추가로 AI 요약 섹션 표시
- history-crud-test 페이지에 영양성분 입력 필드 추가 및 파싱 로직 구현

## 영향을 받는 부분

src/app/history-crud-test
src/app/history
src/app/history/[order]
src/hooks/useTTS.ts
src/utils/parseFoodToRead

## 스크린샷 (선택사항)

<img width="1349" height="898" alt="image" src="https://github.com/user-attachments/assets/8d3bfabb-9a6c-4563-aecc-55eebab32e8e" />

## 이슈

resolves #40
