### PR TITLE
[refactor] useShallow 적용으로 불필요한 리렌더링 방지

### DIFF
--- a/src/app/history/[order]/_components/HistoryInfoContainer.tsx
+++ b/src/app/history/[order]/_components/HistoryInfoContainer.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 
 import { Volume1 } from 'lucide-react'
+import { useShallow } from 'zustand/shallow'
 import { toast } from 'sonner'
 
 import { useTTSStore } from '@/store/ttsStore'
@@ -36,13 +37,15 @@ interface HistoryInfoContainerProps {
  */
 export default function HistoryInfoContainer({ order }: HistoryInfoContainerProps) {
   const { speak, isSpeaking, stopSpeak } = useTTSStore()
-  const { foods, isLoading, isInitialized, lastError, loadFoods } = useFoodStore(state => ({
-    foods: state.foods,
-    isLoading: state.isLoading,
-    isInitialized: state.isInitialized,
-    lastError: state.lastError,
-    loadFoods: state.loadFoods,
-  }))
+  const { foods, isLoading, isInitialized, lastError, loadFoods } = useFoodStore(
+    useShallow(state => ({
+      foods: state.foods,
+      isLoading: state.isLoading,
+      isInitialized: state.isInitialized,
+      lastError: state.lastError,
+      loadFoods: state.loadFoods,
+    }))
+  )
 
   useEffect(() => {
     if (isInitialized) return


### PR DESCRIPTION
## PR 체크리스트

- [x] 코드 변경 사항을 설명하는 커밋 메시지를 작성했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 진행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 빌드/타입 에러 없음
- [x] ESLint/Prettier 적용 (`bun lint`, `bun format`)

## 변경 내용 요약

- HistoryInfoContainer에서 useFoodStore selector에 useShallow 적용
- 스토어 상태 변경 시 불필요한 컴포넌트 리렌더링 최적화

## 영향을 받는 부분

src/app/history/[order]/_components/HistoryInfoContainer.tsx
